### PR TITLE
Force use of conda-build 2.x for long prefix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,13 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # manual reinstallation of conda-build 2.x to build with long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,13 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# conda-build 2.x to get long prefix package
+conda install --yes --quiet conda-build=2
+conda info
+
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/ldflags.patch
+++ b/recipe/ldflags.patch
@@ -1,0 +1,13 @@
+The author of configure.in made quite a strange strange decision here ...
+
+--- configure.orig	2017-01-03 00:06:19.377476176 -0500
++++ configure	2017-01-03 00:06:43.074590422 -0500
+@@ -4165,7 +4165,7 @@
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+-LDFLAGS="$CFLAGS"
++#LDFLAGS="$CFLAGS"
+ LDFLAGS_BIN="$LDFLAGS"
+ 
+ if test "x$FC" = "xnone" ; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
   fn: {{ name }}{{ nodotversion }}.tar.gz
   url: ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/{{ name }}{{ nodotversion }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - ldflags.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 


### PR DESCRIPTION
Manual tweaking to get a long-prefix build while the conda-build 2.x transition is in the works.