### PR TITLE
Add --enable-reentrant flag and build shared library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   global:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-./configure --prefix=$PREFIX || { cat config.log ; exit 1 ; }
-make stand_alone utils
+./configure --prefix=$PREFIX --enable-reentrant || { cat config.log ; exit 1 ; }
+make stand_alone shared utils
 
 # test-ish programs:
 ./cookbook

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,13 +3,14 @@
 set -e
 
 ./configure --prefix=$PREFIX --enable-reentrant || { cat config.log ; exit 1 ; }
-make stand_alone shared utils
+make stand_alone utils
 
 # test-ish programs:
 ./cookbook
 ./speed
 ./testprog
 
+make shared
 make install
 
 # NOTE: don't remove .a files! That's all we provide!

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ test:
     - test -f $PREFIX/lib/libcfitsio.a
     - test -f ${PREFIX}/lib/libcfitsio.so  # [linux]
     - test -f ${PREFIX}/lib/libcfitsio.dylib  # [osx]
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - ldflags.patch
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
@@ -26,6 +26,8 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/libcfitsio.a
+    - test -f ${PREFIX}/lib/libcfitsio.so  # [linux]
+    - test -f ${PREFIX}/lib/libcfitsio.dylib  # [osx]
 
 about:
   home: http://heasarc.gsfc.nasa.gov/fitsio/fitsio.html


### PR DESCRIPTION
Hi,
We have a cfitsio recipe in the [OpenAstronomy](https://github.com/OpenAstronomy/conda-channel/tree/master/recipe_templates/cfitsio) channel, and I noticed that this recipe in conda-forge was added recently. We use the conda-forge channel to build packages, so to avoid conflicts it would be easier to use your package. 
However I noticed a few differences in your recipe, so the proposed changes in this PR:
- the `--enable-reentrant` is needed for parallel programs (OpenMP).
- build also the shared library