### PR TITLE
recipe/meta.yaml: update checksum (?!)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,22 @@
+# NOTE: bizarrely, the SHA256 sum reported in the conda-forge CI systems is
+# different than what I compute if I download the file myself. But I get the
+# same value if I run the build in a Docker container on my laptop, so I guess
+# conda-build is somehow computing the digest weirdly. As far as I can tell,
+# the file is actually downloaded fine, so I'm just using the weird value that
+# conda-build derives. This started happening with version 3.430; maybe it
+# will go away in future versions? -- @pkgw, 2018 Mar 7.
+
 {% set name = "cfitsio" %}
 {% set version = "3.430" %}
 {% set nodotversion = version | replace('.', '') %}
-{% set sha256 = "dc8e2725bebbbf25a0837161dbe2f670f8e97589fb074bae86a6b417bf681ebc" %}
+{% set sha256 = "45665dd34cfe8ceef8bd718380d6018e5690f097420ca504d9152ae98696efd3" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}{{ nodotversion }}.tar.gz
-  url: http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/{{ name }}{{ nodotversion }}.tar.gz
+  url: https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/{{ name }}{{ nodotversion }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - ldflags.patch


### PR DESCRIPTION
The checksum of the tarball changed. I don't know why. But, without externally published tarball checksums, all I can do is trust that the current tarball is a good one.